### PR TITLE
Fix binary encoding of null chunks

### DIFF
--- a/src/Encoders/ByteEncoder.php
+++ b/src/Encoders/ByteEncoder.php
@@ -98,7 +98,7 @@ class ByteEncoder implements EncoderInterface
         }
 
         $cws = [];
-        while(bccomp($sum, 0) > 0) {
+        for ($i = 0; $i < 5; $i++) {
             $cw = bcmod($sum, 900);
             $sum = bcdiv($sum, 900, 0); // Integer division
 

--- a/tests/Encoders/ByteEncoderTest.php
+++ b/tests/Encoders/ByteEncoderTest.php
@@ -76,6 +76,19 @@ class ByteEncoderTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testEncode3()
+    {
+        $be = new ByteEncoder();
+
+        $actual = $be->encode(base64_decode("UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA=="), true);
+        $expected = [901, 134, 501, 627, 198, 376, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        $this->assertSame($expected, $actual);
+
+        $actual = $be->encode(base64_decode("UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA=="), false);
+        $expected = [134, 501, 627, 198, 376, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        $this->assertSame($expected, $actual);
+    }
+
     /**
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Expected first parameter to be a string, array given.


### PR DESCRIPTION
When  encoding binary content (in my case a zip file), when a chunk contains only zeros, it is removed from the output. The following screenshot shows a diff between the hexdumps of the source file and the result after encoding/decoding.

![hexdump diff](https://user-images.githubusercontent.com/16371551/60336283-371d6080-99a0-11e9-858c-4e1048e23f86.png)

This change fixes this behavior to get the same file back after encoding & decoding the file (tested with this reader: https://demo.dynamsoft.com/DBR/BarcodeReaderDemo.aspx).
There still is one problem: the last Byte of the file is not present in the decoded output but I could not find what is causing this.
Anyway, it doesn't seem to bother zip libraries, the file can be read without problem.