### PR TITLE
"Force binary" parameter

### DIFF
--- a/src/DataEncoder.php
+++ b/src/DataEncoder.php
@@ -12,8 +12,9 @@ class DataEncoder
 {
     private $encoders;
     private $defaultEncoder;
+    private $forceBinary;
 
-    public function __construct()
+    public function __construct($forceBinary = false)
     {
         // Encoders sorted in order of preference
         $this->encoders = [
@@ -24,6 +25,8 @@ class DataEncoder
 
         // Default mode is Text
         $this->defaultEncoder = $this->encoders[1];
+
+        $this->forceBinary = $forceBinary;
     }
 
     /**
@@ -106,6 +109,10 @@ class DataEncoder
 
     public function getEncoder($char)
     {
+        if ($this->forceBinary) {
+            return $this->encoders[2];
+        }
+
         foreach ($this->encoders as $encoder) {
             if ($encoder->canEncode($char)) {
                 return $encoder;

--- a/src/PDF417.php
+++ b/src/PDF417.php
@@ -49,6 +49,15 @@ class PDF417
      */
     private $securityLevel = self::DEFAULT_SECURITY_LEVEL;
 
+    /**
+     * Can be used to force binary encoding. This may reduce size of the
+     * barcode if the data contains many encoder changes, such as when
+     * encoding a compressed file.
+     *
+     * @var boolean
+     */
+    private $forceBinaryEncoding = false;
+
     // -- Accessors ------------------------------------------------------------
 
     /**
@@ -111,6 +120,25 @@ class PDF417
         }
 
         $this->securityLevel = intval($securityLevel);
+    }
+
+    /**
+     * Returns whether the binary encoding is forced or not.
+     *
+     * @return integer
+     */
+    public function getForceBinary()
+    {
+        return $this->forceBinaryEncoding;
+    }
+    /**
+     * Force or not the binary encoding for the whole data.
+     *
+     * @param boolean $force
+     */
+    public function setForceBinary($force = true)
+    {
+        $this->forceBinaryEncoding = $force;
     }
 
     // -------------------------------------------------------------------------
@@ -176,7 +204,7 @@ class PDF417
         $secLev = $this->securityLevel;
 
         // Encode data to code words
-        $encoder = new DataEncoder();
+        $encoder = new DataEncoder($this->forceBinaryEncoding);
         $dataWords = $encoder->encode($data);
 
         // Number of code correction words


### PR DESCRIPTION
When trying to encode a zip file, the data contains many encoder changes for a single character, which is not very efficient.

As trying to find an algorithm to better decide which encoder to use would be more complicated, this solution simply allows to force usage of the BytesEncoder. This may be useful when encoding anything else than text data.