### PR TITLE
Allow non-integer scale numbers

### DIFF
--- a/src/Renderers/ImageRenderer.php
+++ b/src/Renderers/ImageRenderer.php
@@ -134,7 +134,7 @@ class ImageRenderer extends AbstractRenderer
         // Add padding
         $width += 2 * $padding;
         $height += 2 * $padding;
-        $img->resizeCanvas($width, $height, 'center', false, $bgColor);
+        $img->resizeCanvas((int)$width, (int)$height, 'center', false, $bgColor);
 
         return $img->encode($format, $quality);
     }


### PR DESCRIPTION
The ImageRenderer accepts a scale number between 1 and 20. The resizeCanvas however requires an integer $width and $height. I may want to scale by 1.4 or 1.5 and should be able to get an integer value for $width and $height. Casting it to an int allows more fine grained scale values