### PR TITLE
fix wrong createDocument parameter type

### DIFF
--- a/src/Renderers/SvgRenderer.php
+++ b/src/Renderers/SvgRenderer.php
@@ -122,7 +122,7 @@ class SvgRenderer extends AbstractRenderer
             "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"
         );
 
-        $doc = $impl->createDocument(null, null, $docType);
+        $doc = $impl->createDocument(null, '', $docType);
         $doc->formatOutput = true;
 
         return $doc;


### PR DESCRIPTION
fix the following deprecation warning:
```
DOMImplementation::createDocument(): Passing null to parameter #2 ($qualifiedName) of type string is deprecated in .../vendor/bigfish/pdf417/src/Renderers/SvgRenderer.php on line 125
```